### PR TITLE
Fix email lookup in XScraper

### DIFF
--- a/project/scraper/x.py
+++ b/project/scraper/x.py
@@ -31,7 +31,7 @@ class XScraper:
       XScraper instance. To start the run call the `.run()` method.    
     """
     self.username = run_config["user"]["name"]
-    self.mail = run_config["user"]["name"]
+    self.mail = run_config["user"]["mail"]
     self.password = run_config["user"]["password"]
     self.log_path = X_LOG_DIR + run_config["log"]["fileName"] + ".txt"
 


### PR DESCRIPTION
## Summary
- correct XScraper to read email address from `run_config["user"]["mail"]`

## Testing
- `pytest`
- `python -m py_compile project/scraper/x.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac2a4013508321be33690816b5d515